### PR TITLE
Add test coverage, language detection, highlight `using`

### DIFF
--- a/src/languages/mint.js
+++ b/src/languages/mint.js
@@ -1,0 +1,114 @@
+export default function(hljs) {
+  var MINT_CONTAINS = [];
+
+  var MINT_KEYWORDS =
+    [ 'const', 'global', 'component', 'store', 'module', 'fun', 'state',
+      'property', 'next', 'if', 'else', 'sequence', 'parallel', 'style',
+      'record', 'connect', 'enum', 'routes', 'try', 'catch', 'case',
+      'where', 'when', 'use', 'for', 'of', 'true', 'false', 'then',
+      'finally', 'get', 'exposing', 'as', 'decode', 'encode' ];
+
+   var XML_IDENT_RE = '[A-Za-z0-9\\._:-]+';
+
+   var TAG_INTERNALS = {
+    endsWithParent: true,
+    illegal: /</,
+    relevance: 0,
+    contains: [
+      {
+        begin: XML_IDENT_RE,
+        className: 'attr',
+        relevance: 0
+      },
+      {
+        begin: /=\s*/,
+        relevance: 0,
+        contains: [
+          {
+            contains: MINT_CONTAINS,
+            endsParent: true,
+            className: 'tag',
+            begin: '\\{',
+            end: '\\}',
+          },
+          {
+            className: 'string',
+            endsParent: true,
+            variants: [
+              {begin: /"/, end: /"/},
+              {begin: /'/, end: /'/}
+            ]
+          }
+        ]
+      }
+    ]
+  };
+
+  MINT_CONTAINS.push(
+    ...[
+      hljs.COMMENT("/\\*", "\\*/"),
+      {
+        begin: "\\b\\d+(\\.\\d+)?",
+        className: 'number',
+        end: "\\B|\\b"
+      },
+      {
+        className: 'string',
+        begin: '"',
+        end: '"'
+      },
+      {
+        begin: "\\b[A-Z][A-Za-z0-9]+",
+        ends: "[^A-Za-z0-9]",
+        className: 'type'
+      },
+      {
+        contains: MINT_CONTAINS,
+        begin: '<{', end: '}>',
+        className: 'tag'
+      },
+      {
+        begin: '</?', end: '/?>',
+        className: 'tag',
+        contains: [
+          {
+            begin: /[^\/><\s]+/,
+            className: 'name',
+            relevance: 0
+          },
+          TAG_INTERNALS
+        ]
+      },
+      {
+        keywords: MINT_KEYWORDS,
+        begin: 'style\\s+[a-zA-Z0-9-]+\\s*{',
+        end: '}',
+        contains: [
+          {
+            begin: '(?=[-a-zA-Z0-9]+\\s*:\\s*[^;]+)',
+            end: ';',
+            contains: [
+              {
+                begin: '[-a-zA-Z0-9]+\\s*',
+                className: 'string',
+                excludeEnd: true,
+                end: ':',
+              },
+              {
+                excludeEnd: true,
+                endsParent: true,
+                begin: '[^;]+',
+                end: ';',
+              }
+            ]
+          }
+        ]
+      }
+   ])
+
+  return {
+    contains: MINT_CONTAINS,
+    keywords: MINT_KEYWORDS,
+    name: "Mint"
+  }
+}

--- a/src/languages/mint.js
+++ b/src/languages/mint.js
@@ -1,6 +1,6 @@
 /*
 Language: Mint
-Author: John Smith <email@domain.com>
+Author: Szikszai Gusztáv <github.com/gdotdesign>
 Contributors: Luke Pighetti <github.com/lukepighetti>
 Description: A refreshing programming language for the front-end web.
 Website: https://www.mint-lang.com

--- a/src/languages/mint.js
+++ b/src/languages/mint.js
@@ -1,12 +1,20 @@
+/*
+Language: Mint
+Author: John Smith <email@domain.com>
+Contributors: Luke Pighetti <github.com/lukepighetti>
+Description: A refreshing programming language for the front-end web.
+Website: https://www.mint-lang.com
+*/
+
 export default function(hljs) {
   var MINT_CONTAINS = [];
 
   var MINT_KEYWORDS =
     [ 'const', 'global', 'component', 'store', 'module', 'fun', 'state',
-      'property', 'next', 'if', 'else', 'sequence', 'parallel', 'style',
+      'property', 'next', 'if', 'else', 'sequence', 'parallel|10', 'style',
       'record', 'connect', 'enum', 'routes', 'try', 'catch', 'case',
       'where', 'when', 'use', 'for', 'of', 'true', 'false', 'then',
-      'finally', 'get', 'exposing', 'as', 'decode', 'encode' ];
+      'finally', 'get', 'exposing|10', 'as', 'decode', 'encode', 'using|10' ];
 
    var XML_IDENT_RE = '[A-Za-z0-9\\._:-]+';
 
@@ -50,6 +58,7 @@ export default function(hljs) {
       {
         begin: "\\b\\d+(\\.\\d+)?",
         className: 'number',
+        relevance: 0,
         end: "\\B|\\b"
       },
       {
@@ -60,6 +69,7 @@ export default function(hljs) {
       {
         begin: "\\b[A-Z][A-Za-z0-9]+",
         ends: "[^A-Za-z0-9]",
+        relevance: 0,
         className: 'type'
       },
       {
@@ -107,8 +117,8 @@ export default function(hljs) {
    ])
 
   return {
-    contains: MINT_CONTAINS,
+    name: "Mint",
     keywords: MINT_KEYWORDS,
-    name: "Mint"
+    contains: MINT_CONTAINS,
   }
 }

--- a/test/detect/mint/default.txt
+++ b/test/detect/mint/default.txt
@@ -1,0 +1,34 @@
+/* Records provide equality and serialization tools */
+record Lang {
+  name : String,
+  fans : Number using "super_fans"
+}
+
+/* Stores handle state and mutations */
+store Application {
+  state lang : Lang = Lang("Mint", 42)
+  state love : Number = 5
+
+  fun giveLove : Promise(Never, Void) {
+    next { love = love + 1 }
+  }
+}
+
+/* Components are dynamically styled and connect stores */
+component Main {
+  connect Application exposing { love }
+
+  style base {
+    display: flex;
+
+    if (love > 5) {
+      color: red;
+    }
+  }
+
+  fun render : Html {
+    <div::base>
+      "#{lang.name} has #{lang.fans} fans"
+    </div>
+  }
+}

--- a/test/markup/mint/default.expect.txt
+++ b/test/markup/mint/default.expect.txt
@@ -1,0 +1,34 @@
+<span class="hljs-comment">/* Records provide equality and serialization tools */</span>
+<span class="hljs-14">record</span> <span class="hljs-type">Lang</span> {
+  name : <span class="hljs-type">String</span>,
+  fans : <span class="hljs-type">Number</span> <span class="hljs-35">using</span> <span class="hljs-string">"super_fans"</span>
+}
+
+<span class="hljs-comment">/* Stores handle state and mutations */</span>
+<span class="hljs-3">store</span> <span class="hljs-type">Application</span> {
+  <span class="hljs-6">state</span> lang : <span class="hljs-type">Lang</span> = <span class="hljs-type">Lang</span>(<span class="hljs-string">"Mint"</span>, <span class="hljs-number">42</span>)
+  <span class="hljs-6">state</span> love : <span class="hljs-type">Number</span> = <span class="hljs-number">5</span>
+
+  <span class="hljs-5">fun</span> giveLove : <span class="hljs-type">Promise</span>(<span class="hljs-type">Never</span>, <span class="hljs-type">Void</span>) {
+    <span class="hljs-8">next</span> { love = love + <span class="hljs-number">1</span> }
+  }
+}
+
+<span class="hljs-comment">/* Components are dynamically styled and connect stores */</span>
+<span class="hljs-2">component</span> <span class="hljs-type">Main</span> {
+  <span class="hljs-15">connect</span> <span class="hljs-type">Application</span> <span class="hljs-31">exposing</span> { love }
+
+  <span class="hljs-13">style</span> base {
+    <span class="hljs-string">display</span>: flex;
+
+    <span class="hljs-9">if</span> (love &gt; 5) {
+      <span class="hljs-string">color</span>: red;
+    }
+  }
+
+  <span class="hljs-5">fun</span> render : <span class="hljs-type">Html</span> {
+    <span class="hljs-tag">&lt;<span class="hljs-name">div::base</span>&gt;</span>
+      <span class="hljs-string">"#{lang.name} has #{lang.fans} fans"</span>
+    <span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span>
+  }
+}

--- a/test/markup/mint/default.txt
+++ b/test/markup/mint/default.txt
@@ -1,0 +1,34 @@
+/* Records provide equality and serialization tools */
+record Lang {
+  name : String,
+  fans : Number using "super_fans"
+}
+
+/* Stores handle state and mutations */
+store Application {
+  state lang : Lang = Lang("Mint", 42)
+  state love : Number = 5
+
+  fun giveLove : Promise(Never, Void) {
+    next { love = love + 1 }
+  }
+}
+
+/* Components are dynamically styled and connect stores */
+component Main {
+  connect Application exposing { love }
+
+  style base {
+    display: flex;
+
+    if (love > 5) {
+      color: red;
+    }
+  }
+
+  fun render : Html {
+    <div::base>
+      "#{lang.name} has #{lang.fans} fans"
+    </div>
+  }
+}


### PR DESCRIPTION
This pull request meets all requirements for submission to https://github.com/highlightjs/highlight.js

Changes: 

- Adds a basic example for `highlight.js` showcase website
- Adds metadata for language name, author, contributors, description, website
- Handles language detection
- Adds highlight for keyword `using`

Review:

- @gdotdesign Please check the Author metadata and make sure you're comfortable with how I represented you
